### PR TITLE
Added the DBFieldType of varchar to the where condition as it should also take precedence.

### DIFF
--- a/XMLParser/XML/XmlAnalyser.cs
+++ b/XMLParser/XML/XmlAnalyser.cs
@@ -76,7 +76,7 @@ namespace XMLParser.XML
                     var subNodeNameList = existingNode.DBFields;
                     subNodeNameList.AddRange(GetNodeNames(item.ChildNodes, item.Name, primaryKeyName));
                     var distinctWithoutUnkowns = subNodeNameList.OrderByDescending(field => field.Length).Distinct().Where(x => x.DBFieldType != DBFieldType.unkown);
-                    var allDoubleDifferentTyp = distinctWithoutUnkowns.SelectMany(x => distinctWithoutUnkowns.Where(y => x.Name == y.Name && x.DBFieldType != y.DBFieldType)).Where(x => x.DBFieldType != DBFieldType.@double).Distinct();
+                    var allDoubleDifferentTyp = distinctWithoutUnkowns.SelectMany(x => distinctWithoutUnkowns.Where(y => x.Name == y.Name && x.DBFieldType != y.DBFieldType)).Where(x => x.DBFieldType != DBFieldType.@double && x.DBFieldType != DBFieldType.varchar).Distinct();
                     subNodeNameList = distinctWithoutUnkowns.Except(allDoubleDifferentTyp).ToList();
                     DBTable newEntry = new DBTable(existingNode.Name, subNodeNameList);
                     nodeNames.Remove(existingNode);

--- a/XMLParser/XML/XmlAnalyser.cs
+++ b/XMLParser/XML/XmlAnalyser.cs
@@ -76,6 +76,7 @@ namespace XMLParser.XML
                     var subNodeNameList = existingNode.DBFields;
                     subNodeNameList.AddRange(GetNodeNames(item.ChildNodes, item.Name, primaryKeyName));
                     var distinctWithoutUnkowns = subNodeNameList.OrderByDescending(field => field.Length).Distinct().Where(x => x.DBFieldType != DBFieldType.unkown);
+                    //Possible Bug when varchar && double DBField!!
                     var allDoubleDifferentTyp = distinctWithoutUnkowns.SelectMany(x => distinctWithoutUnkowns.Where(y => x.Name == y.Name && x.DBFieldType != y.DBFieldType)).Where(x => x.DBFieldType != DBFieldType.@double && x.DBFieldType != DBFieldType.varchar).Distinct();
                     subNodeNameList = distinctWithoutUnkowns.Except(allDoubleDifferentTyp).ToList();
                     DBTable newEntry = new DBTable(existingNode.Name, subNodeNameList);


### PR DESCRIPTION
Made it so that varchar and double take precedence if there are multiple DBFields with the same type and name. 